### PR TITLE
Fix building, fix installation

### DIFF
--- a/clients/code/package.json
+++ b/clients/code/package.json
@@ -24,7 +24,7 @@
   "main": "./out/extension.js",
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "compile": "rd /s /q out && tsc -p ./",
+    "compile": "rimraf out && tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile && npm run lint",
     "lint": "eslint src",
@@ -34,14 +34,15 @@
     "vscode-languageclient": "9.0.1"
   },
   "devDependencies": {
-    "@types/vscode": "^1.93.0",
     "@types/mocha": "^10.0.7",
     "@types/node": "20.x",
+    "@types/vscode": "^1.93.0",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",
-    "eslint": "^9.9.1",
-    "typescript": "^5.5.4",
     "@vscode/test-cli": "^0.0.10",
-    "@vscode/test-electron": "^2.4.1"
+    "@vscode/test-electron": "^2.4.1",
+    "eslint": "^9.9.1",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.5.4"
   }
 }

--- a/clients/code/src/extension.ts
+++ b/clients/code/src/extension.ts
@@ -24,6 +24,7 @@ export async function activate(context: ExtensionContext) {
 		const url = info?.assets.find(a => a.name === robust_name)?.browser_download_url;
 
 		if (!url) {
+			await window.showInformationMessage(`Cannot find suitable version of robust-lsp for your platform ${process.platform} with arch ${process.arch}. You can check out extension Github and create issue if it's a bug`);
 			deactivate();
 			return;
 		}
@@ -144,7 +145,7 @@ function f(s: string, init?: RequestInit): Promise<Response> {
 }
 
 function getExecutableFilename(): string {
-	return `robust-lsp${process.platform === 'win32' ? '.exe' : ''}`;
+	return `robust-lsp-${process.platform === 'win32' ? 'win-x86_64.exe' : 'linux-x86_64'}`;
 }
 
 interface GitHubReleasesAPIResponse {


### PR DESCRIPTION
Брат, спасибо за языковой сервер, от души.
Но смотри какая проблема: расширение запрашивает с Github `robust-lsp.exe`, да? Или просто `robust-lsp` если это Линукс. Но вот не задача, в релизах у тебя таких нет, есть только `robust-lsp-linux-x86_64` да `robust-lsp-win-x86_64.exe`.
Так что либо уж переименовывать файлы в релизах, либо вот этот PR прими.

Я здесь также ещё закомитил замену rd на rimraf - его просто не находит на большинстве облочек командной строки и даже с F5 от VSC не работает.